### PR TITLE
fix: unify agent vitals reporting across UI and API (fixes #7)

### DIFF
--- a/src/voice/server.ts
+++ b/src/voice/server.ts
@@ -69,6 +69,55 @@ function isMomentWorthy(text: string): boolean {
 }
 
 let vitalsTokenCount = 0;
+
+// ── Centralized vitals snapshot ────────────────────────────────────────
+// All surfaces (API, UI, logs) share the same cached snapshot so values
+// are always consistent regardless of who reads them or when.
+interface VitalsSnapshot {
+	cpu: number;
+	mem: number;
+	heapUsed: number;
+	heapTotal: number;
+	uptime: number;
+	tokens: number;
+	ts: number; // unix-ms when this snapshot was taken
+}
+
+let _lastCpuUsage = process.cpuUsage();
+let _lastCpuTime = process.hrtime.bigint();
+let _vitalsCache: VitalsSnapshot | null = null;
+const VITALS_CACHE_MS = 1000; // cache for 1s — all readers within 1s see identical values
+
+function getVitalsSnapshot(): VitalsSnapshot {
+	const now = Date.now();
+	if (_vitalsCache && now - _vitalsCache.ts < VITALS_CACHE_MS) return _vitalsCache;
+
+	const mem = process.memoryUsage();
+	const currentCpu = process.cpuUsage();
+	const currentTime = process.hrtime.bigint();
+
+	// Delta-based CPU: measure CPU microseconds consumed since last sample
+	const userDelta = currentCpu.user - _lastCpuUsage.user;
+	const sysDelta = currentCpu.system - _lastCpuUsage.system;
+	const wallDeltaUs = Number(currentTime - _lastCpuTime) / 1000; // ns → µs
+	const cpuPercent = wallDeltaUs > 0
+		? Math.min(100, Math.round((userDelta + sysDelta) / wallDeltaUs * 100))
+		: 0;
+
+	_lastCpuUsage = currentCpu;
+	_lastCpuTime = currentTime;
+
+	_vitalsCache = {
+		cpu: cpuPercent,
+		mem: Math.round(mem.rss / 1024 / 1024),
+		heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
+		heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
+		uptime: Math.round(process.uptime()),
+		tokens: vitalsTokenCount,
+		ts: now,
+	};
+	return _vitalsCache;
+}
 const PHOTOS_DIR = "memory/photos";
 const INDEX_FILE = "memory/photos/INDEX.md";
 const LATEST_FRAME_FILE = "memory/.latest-frame.jpg";
@@ -1595,17 +1644,7 @@ ${runningContext}`;
 			jsonReply(res, 200, { status: "ok" });
 
 		} else if (url.pathname === "/api/vitals") {
-			const mem = process.memoryUsage();
-			const cpuUsage = process.cpuUsage();
-			const cpuPercent = Math.min(100, Math.round((cpuUsage.user + cpuUsage.system) / 1000 / (process.uptime() * 10000)));
-			jsonReply(res, 200, {
-				cpu: cpuPercent,
-				mem: Math.round(mem.rss / 1024 / 1024),
-				heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
-				heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
-				uptime: Math.round(process.uptime()),
-				tokens: vitalsTokenCount,
-			});
+			jsonReply(res, 200, getVitalsSnapshot());
 
 		} else if (url.pathname === "/" || url.pathname === "/test") {
 			res.writeHead(200, { "Content-Type": "text/html" });

--- a/src/voice/ui.html
+++ b/src/voice/ui.html
@@ -1747,14 +1747,19 @@ function connectWS(){if(ws)return;setStatus('Connecting...','');ws=new WebSocket
 function sendMsg(m){if(ws&&ws.readyState===WebSocket.OPEN)ws.send(JSON.stringify(m));}
 
 // Agent Vitals
-var vitalsStart=Date.now(), vitalsTokenCount=0, vitalsMaxTokens=200000;
+var vitalsTokenCount=0, vitalsMaxTokens=200000, vitalsServerUptime=0;
 var waveData=[], waveCanvas=document.getElementById('vitalsWaveCanvas'), waveCtx=waveCanvas?waveCanvas.getContext('2d'):null;
 
-function updateUptime(){
-  var s=Math.floor((Date.now()-vitalsStart)/1000);
+function formatUptime(s){
   var h=Math.floor(s/3600), m=Math.floor((s%3600)/60), sec=s%60;
+  return (h>0?(h+':'):'')+String(m).padStart(2,'0')+':'+String(sec).padStart(2,'0');
+}
+function updateUptime(){
+  // Interpolate locally between API polls for smooth display,
+  // but base value always comes from the server snapshot
+  vitalsServerUptime++;
   var el=document.getElementById('vitalUptime');
-  if(el) el.innerHTML=(h>0?(h+':'):'')+String(m).padStart(2,'0')+':'+String(sec).padStart(2,'0');
+  if(el) el.innerHTML=formatUptime(vitalsServerUptime);
 }
 setInterval(updateUptime,1000);
 
@@ -1782,6 +1787,8 @@ function pollSystemVitals(){
       if(memBar)memBar.style.width=Math.min(100,Math.round(mb/4096*100))+'%';
     }
     if(d.tokens!==undefined) updateVitalTokens(d.tokens);
+    // Sync uptime from server snapshot so UI matches API
+    if(d.uptime!==undefined) vitalsServerUptime=d.uptime;
     // Push to wave
     waveData.push(d.cpu||0);
     if(waveData.length>60) waveData.shift();


### PR DESCRIPTION
## Problem

Agent vitals (CPU, memory, uptime, tokens) are reported inconsistently between the dashboard UI and the API endpoint. Different surfaces show different values, causing confusion about the agent's actual state.

### Root Causes

1. **Uptime mismatch**: UI computed uptime from `Date.now()` at page load (browser time), while API returned `process.uptime()` (server process time). Opening the dashboard 30 minutes after server start meant they'd permanently differ by 30 minutes.

2. **CPU calculation**: API used cumulative `process.cpuUsage()` divided by total process lifetime, giving a lifetime average instead of instantaneous utilization — misleading when comparing against the UI's 2-second poll interval.

3. **No shared snapshot**: Each API call independently computed `process.memoryUsage()`, `process.cpuUsage()`, and `process.uptime()` at slightly different instants, so concurrent consumers (multiple browser tabs, external API clients) could see divergent values.

## Fix

- **Centralized `getVitalsSnapshot()`** with 1-second cache — all surfaces (API, UI, future log consumers) read the same frozen snapshot within any 1s window
- **Delta-based CPU measurement** using `process.hrtime.bigint()` for accurate instantaneous CPU readings instead of lifetime averages
- **UI syncs uptime from server** response on each 2s poll, with 1s local interpolation for smooth display. Removed the client-side `vitalsStart = Date.now()` uptime calculation entirely.
- **Response includes `ts` field** (unix-ms) so consumers know exactly when the snapshot was taken

## Changes

- `src/voice/server.ts`: Add `VitalsSnapshot` interface, `getVitalsSnapshot()` with caching and delta CPU. Replace inline vitals computation in `/api/vitals` handler.
- `src/voice/ui.html`: Remove `vitalsStart`, use `vitalsServerUptime` synced from API. Add uptime sync in `pollSystemVitals()`.

Fixes #7