### PR TITLE
fix: enable skills search filtering in dashboard (fixes #10)

### DIFF
--- a/src/voice/server.ts
+++ b/src/voice/server.ts
@@ -2208,6 +2208,19 @@ ${runningContext}`;
 (function() {
   const PROXY_BASE = '/api/skills-mp/proxy?path=';
 
+  // Build a proxy URL that keeps query params as top-level params
+  // so the server can forward them (e.g. ?q=docker) to skills.sh.
+  // Without this, "/?q=docker" becomes "proxy?path=/?q=docker" and
+  // the q param is buried inside the path value — nuqs/Next.js
+  // cannot read it back from location.search, breaking search.
+  function proxyUrl(rawUrl) {
+    var qi = rawUrl.indexOf('?');
+    if (qi === -1) return PROXY_BASE + rawUrl;
+    var pathname = rawUrl.slice(0, qi);
+    var qs = rawUrl.slice(qi + 1);           // e.g. "q=docker&view=all"
+    return PROXY_BASE + encodeURIComponent(pathname) + '&' + qs;
+  }
+
   // Fetch installed skills from lock file
   var __installedSkills = new Set();
   var __installedSources = new Set();
@@ -2223,11 +2236,11 @@ ${runningContext}`;
   window.fetch = function(url, opts) {
     if (typeof url === 'string') {
       if (url.startsWith('/') && !url.startsWith('//') && !url.startsWith('/api/skills-mp/')) {
-        url = PROXY_BASE + url;
+        url = proxyUrl(url);
       } else if (url.startsWith(location.origin + '/')) {
         var path = url.slice(location.origin.length);
         if (!path.startsWith('/api/skills-mp/')) {
-          url = PROXY_BASE + path;
+          url = proxyUrl(path);
         }
       }
     } else if (url instanceof Request) {
@@ -2235,7 +2248,7 @@ ${runningContext}`;
       if (rUrl.startsWith(location.origin + '/')) {
         var rPath = rUrl.slice(location.origin.length);
         if (!rPath.startsWith('/api/skills-mp/')) {
-          url = new Request(PROXY_BASE + rPath, url);
+          url = new Request(proxyUrl(rPath), url);
         }
       }
     }
@@ -2248,11 +2261,11 @@ ${runningContext}`;
     var args = Array.prototype.slice.call(arguments, 2);
     if (typeof url === 'string') {
       if (url.startsWith('/') && !url.startsWith('//') && !url.startsWith('/api/skills-mp/')) {
-        url = PROXY_BASE + url;
+        url = proxyUrl(url);
       } else if (url.startsWith(location.origin + '/')) {
         var path = url.slice(location.origin.length);
         if (!path.startsWith('/api/skills-mp/')) {
-          url = PROXY_BASE + path;
+          url = proxyUrl(path);
         }
       }
     }
@@ -2264,7 +2277,7 @@ ${runningContext}`;
   var _replaceState = history.replaceState;
   function rewriteHistoryUrl(originalFn, data, title, url) {
     if (typeof url === 'string' && url.startsWith('/') && !url.startsWith('//') && !url.startsWith('/api/skills-mp/')) {
-      url = PROXY_BASE + url;
+      url = proxyUrl(url);
     }
     return originalFn.call(history, data, title, url);
   }
@@ -2279,7 +2292,7 @@ ${runningContext}`;
     if (action && action.startsWith('/') && !action.startsWith('//') && !action.startsWith('/api/skills-mp/')) {
       e.preventDefault();
       var params = new URLSearchParams(new FormData(form)).toString();
-      window.location.href = PROXY_BASE + action + (params ? (action.includes('?') ? '&' : '?') + params : '');
+      window.location.href = proxyUrl(action + (params ? (action.includes('?') ? '&' : '?') + params : ''));
     }
   }, true);
 
@@ -2354,11 +2367,11 @@ ${runningContext}`;
     // Internal skills.sh links
     if (href.startsWith('/') && !href.startsWith('//')) {
       e.preventDefault();
-      window.location.href = PROXY_BASE + href;
+      window.location.href = proxyUrl(href);
     } else if (href.startsWith('https://skills.sh/') || href.startsWith('https://skillsmp.com/')) {
       e.preventDefault();
-      const path = new URL(href).pathname;
-      window.location.href = PROXY_BASE + path;
+      var parsed = new URL(href);
+      window.location.href = proxyUrl(parsed.pathname + parsed.search);
     }
   }, true);
 


### PR DESCRIPTION
## Problem

The search functionality in the Skills section (proxied from skills.sh) was broken. Typing in the search input field did not filter skills — the list remained unchanged.

## Root Cause

The skills marketplace proxy in `server.ts` rewrites all URLs by concatenating `PROXY_BASE + url`, where `PROXY_BASE = '/api/skills-mp/proxy?path='`.

When `nuqs` (the URL state management library used by skills.sh) updates the URL to add a search query — e.g., `/?q=docker` — the proxy interceptor rewrites it to:
```
/api/skills-mp/proxy?path=/?q=docker
```

This buries the `q` parameter inside the `path` value. The browser's `URLSearchParams` sees `path=/?q=docker` as a single param, so `nuqs` can never read back the `q` parameter from `location.search`, and the search state is effectively lost.

The same issue affects `fetch`, `XMLHttpRequest`, `pushState`, `replaceState`, link clicks, and form submissions.

## Fix

Introduced a `proxyUrl()` helper that splits the raw URL into pathname and query string:
- `/?q=docker` → `/api/skills-mp/proxy?path=%2F&q=docker`
- `/official?q=test&view=all` → `/api/skills-mp/proxy?path=%2Fofficial&q=test&view=all`

The pathname is `encodeURIComponent`-encoded so it's safely contained in the `path` param, while query params like `q` become top-level params that:
1. **nuqs can read** from `location.search` (fixing the search UI state)
2. **The server proxy can forward** to skills.sh (the server already strips `path` and forwards remaining params)

All URL rewriting call sites (`fetch`, `XHR`, `pushState`, `replaceState`, link clicks, form submissions) now use `proxyUrl()` instead of raw concatenation.

## Testing

- Paths without query strings are unchanged: `/` → `proxy?path=/` (same as before)
- Paths with query strings now correctly preserve params: `/?q=docker` → `proxy?path=%2F&q=docker`
- Server-side `searchParams.get('path')` returns the URL-decoded pathname ✅
- Server-side forwards `q=docker` to skills.sh ✅

Fixes #10