### PR TITLE
fix: allow creating markdown (.md) files (fixes #11)

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -318,8 +318,8 @@ export async function loadAgent(
 
 Your working directory is \`${agentDir}\`.
 
-When creating files (documents, PDFs, images, spreadsheets, code output, exports, assets, etc.), write them to the \`workspace/\` directory by default.
-- Example: \`workspace/report.pdf\`, \`workspace/chart.png\`, \`workspace/data.csv\`
+When creating files (documents, markdown files, PDFs, images, spreadsheets, code output, exports, assets, etc.), write them to the \`workspace/\` directory by default.
+- Example: \`workspace/report.pdf\`, \`workspace/chart.png\`, \`workspace/data.csv\`, \`workspace/todo.md\`
 - The \`workspace/\` directory is the designated output folder for generated artifacts
 - If the user explicitly specifies a path (e.g. "create ~/notes/todo.md"), use the path they requested
 - This rule applies to ALL channels: voice, chat, Telegram, WhatsApp`);

--- a/src/voice/server.ts
+++ b/src/voice/server.ts
@@ -435,7 +435,7 @@ export async function startVoiceServer(opts: VoiceServerOptions): Promise<() => 
 			const { tools: composioTools, promptSuffix: composioPromptSuffix } = await getComposioContext(prompt);
 
 			let systemPromptSuffix = getCurrentDateTimeContext();
-			systemPromptSuffix += "\nWhen creating files (PDFs, images, documents, code output, etc.), write them to the workspace/ directory by default. If the user explicitly specifies a different path, use the path they requested.";
+			systemPromptSuffix += "\nWhen creating files (PDFs, images, documents, markdown files, code output, etc.), write them to the workspace/ directory by default. If the user explicitly specifies a different path, use the path they requested.";
 			if (whatsappSock && whatsappConnected) {
 				systemPromptSuffix += "\nYou can send WhatsApp messages using the send_whatsapp_message tool and set up auto-response triggers using create_trigger.";
 			} else {
@@ -905,7 +905,7 @@ ${runningContext}`;
 							const tgComposio = await getComposioContext(fullText);
 							let tgSystemPrompt = "You are an AI assistant responding to a Telegram user. " +
 								"Any files you create or modify will be AUTOMATICALLY sent back to the user on Telegram. " +
-								"When asked to create documents (PDF, Word, PPT, spreadsheets, images, text files, etc.), " +
+								"When asked to create documents (PDF, Word, PPT, spreadsheets, images, markdown files, text files, etc.), " +
 								"write them to the workspace/ directory. The files will be delivered to the user immediately after you finish. " +
 								"Keep text responses concise since they appear in a chat interface.";
 							if (whatsappSock && whatsappConnected) {
@@ -1411,7 +1411,7 @@ ${runningContext}`;
 					const waComposio = await getComposioContext(text);
 					let waSystemPrompt = "You are an AI assistant responding via WhatsApp. " +
 						"Any files you create or modify will be AUTOMATICALLY sent back to the user on WhatsApp. " +
-						"When asked to create documents, write them to the workspace/ directory. " +
+						"When asked to create documents or markdown files, write them to the workspace/ directory. " +
 						"Keep text responses concise since they appear in a chat interface. " +
 						"You can send WhatsApp messages to other people using the send_whatsapp_message tool. " +
 						"If you don't know a contact's number, ask the user or use list_whatsapp_contacts to check saved contacts. " +


### PR DESCRIPTION
## Problem

Users cannot create markdown (.md) files. The system prompt instructions for file creation in the workspace directory did not mention markdown files, causing the agent to be unsure where to place .md files or whether they should be treated as workspace artifacts.

The file type lists in 4 separate system prompt locations only mentioned: documents, PDFs, images, spreadsheets, code output, exports, assets, text files — but never markdown.

## Fix

Added "markdown files" to all file creation instructions across:
- `src/loader.ts` — main system prompt workspace instructions
- `src/voice/server.ts` — browser voice UI, Telegram, and WhatsApp system prompts

Also added `workspace/todo.md` as an example path so the agent knows .md files belong in workspace/ by default.

## Changes
- `src/loader.ts`: Added "markdown files" to the file type list and `workspace/todo.md` example
- `src/voice/server.ts`: Added "markdown files" to 3 system prompt locations (browser, Telegram, WhatsApp)

Fixes #11