### PR TITLE
fix: resolve SkillsFlow skills display issue (fixes #12)

### DIFF
--- a/skills/gmail-email/SKILL.md
+++ b/skills/gmail-email/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: gmail-email
+description: Send emails via Gmail SMTP using App Password authentication.
+---
+
 # Gmail Email Skill
 
 Send emails via Gmail SMTP.

--- a/src/voice/ui.html
+++ b/src/voice/ui.html
@@ -1378,7 +1378,7 @@ function switchView(v){
   if(v==='integrations'&&!integrationsLoaded){loadToolkits();integrationsLoaded=true;}
   if(v==='comms'&&!commsLoaded){loadTelegramStatus();loadWhatsAppStatus();loadPhoneWebhookUrl();commsLoaded=true;}
   if(v==='skills'&&!skillsLoaded){document.getElementById('skillsFrame').src='/api/skills-mp/proxy?path=/';skillsLoaded=true;}
-  if(v==='flows'&&!flowsLoaded){loadFlowSkills();loadSavedFlows();flowsLoaded=true;}
+  if(v==='flows'){loadFlowSkills();loadSavedFlows();flowsLoaded=true;}
   if(v==='scheduler'&&!schedulerLoaded){loadSchedules();schedulerLoaded=true;}
 }
 // Skills MP install handler
@@ -1427,7 +1427,7 @@ function loadFlowSkills() {
     flowSkillsCache = d.skills || [];
     document.getElementById('flowSkillsSearch').value = '';
     renderFlowSkillsList(flowSkillsCache);
-  }).catch(function(){});
+  }).catch(function(err){ console.error('loadFlowSkills error:', err); });
   refreshFlowCommsStatus();
 }
 
@@ -1963,7 +1963,7 @@ function handleServerMessage(m){switch(m.type){
     thinkingEl.querySelector('.thinking-text').textContent+=m.text;
     conv.scrollTop=conv.scrollHeight;
     break;
-  case'files_changed':refreshFileTree();break;
+  case'files_changed':refreshFileTree();if(currentView==='flows'){loadFlowSkills();}break;
   case'error':appendConv('Error: '+escHtml(m.message),'system');break;
   case'schedule_start':
     var schEl=document.createElement('div');


### PR DESCRIPTION
## Problem

The SkillsFlow page shows 'No skills installed' even when skills are installed via the marketplace. Screenshot from the issue shows a blank SkillsFlow panel with no skills listed.

## Root Cause

Three issues contributed:

1. **Skills list cached and never refreshed**: The `flowsLoaded` flag caused `loadFlowSkills()` to only execute once. After the first load, switching away and back to SkillsFlow would never re-fetch the skills list — so if skills were installed after the first visit, they'd never appear.

2. **`files_changed` event didn't update SkillsFlow**: When skills were installed via the marketplace, a `files_changed` WebSocket event was broadcast. This only triggered `refreshFileTree()` but never refreshed the SkillsFlow skills panel.

3. **Built-in `gmail-email` skill missing frontmatter**: The `gmail-email` skill had no YAML frontmatter (`name`/`description`), so `discoverSkills()` silently skipped it.

## Fix

- Always reload skills when switching to the SkillsFlow tab (remove one-time-load gate)
- Refresh SkillsFlow skills panel on `files_changed` events when viewing SkillsFlow
- Add proper frontmatter to the `gmail-email` built-in skill
- Log errors in `loadFlowSkills()` instead of silently swallowing them

Fixes #12