### PR TITLE
chore: publish as scoped @open-gitagent/gitagent

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -60,7 +60,7 @@ curl -fsSL https://raw.githubusercontent.com/open-gitagent/gitagent/main/install
 
 **Manual install:**
 ```bash
-npm install -g gitagent
+npm install -g @open-gitagent/gitagent
 mkdir ~/assistant && cd ~/assistant && git init
 gitagent --voice --dir .
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This will:
 ### Or install manually:
 
 ```bash
-npm install -g gitagent
+npm install -g @open-gitagent/gitagent
 ```
 
 ## Quick Start
@@ -756,7 +756,7 @@ Your agent lives in a git repository with structured files:
 ### Installation & Setup
 
 **What are the requirements?**
-Node.js 18+ (or 20+ recommended), npm, and git. Install globally with `npm install -g gitagent`.
+Node.js 18+ (or 20+ recommended), npm, and git. Install globally with `npm install -g @open-gitagent/gitagent`.
 
 **How do I set up API keys?**
 Run the installer for guided setup:

--- a/install.sh
+++ b/install.sh
@@ -107,8 +107,8 @@ if [ "$(uname)" != "Darwin" ] && ! npm root -g 2>/dev/null | grep -q "$HOME"; th
 fi
 
 if command -v gitagent &>/dev/null; then
-  INSTALLED_VER="$(npm ls -g gitagent --depth=0 --json 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).dependencies?.gitagent?.version || ''" 2>/dev/null || echo "")"
-  LATEST_VER="$(npm view gitagent version 2>/dev/null || echo "")"
+  INSTALLED_VER="$(npm ls -g @open-gitagent/gitagent --depth=0 --json 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).dependencies?.['@open-gitagent/gitagent']?.version || ''" 2>/dev/null || echo "")"
+  LATEST_VER="$(npm view @open-gitagent/gitagent version 2>/dev/null || echo "")"
 
   if [ -n "$INSTALLED_VER" ] && [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" != "$LATEST_VER" ]; then
     echo -e "  ${YELLOW}⬆${NC}  gitagent ${DIM}v${INSTALLED_VER}${NC} installed — ${GREEN}v${LATEST_VER}${NC} available"
@@ -116,7 +116,7 @@ if command -v gitagent &>/dev/null; then
     UPDATE_CHOICE="${UPDATE_CHOICE:-Y}"
     if [[ "$UPDATE_CHOICE" =~ ^[Yy] ]]; then
       echo -e "  ${BOLD}Updating gitagent...${NC}"
-      $NPM_CMD install -g gitagent@latest 2>&1 | tail -2
+      $NPM_CMD install -g @open-gitagent/gitagent@latest 2>&1 | tail -2
       echo -e "  ${GREEN}✓${NC} gitagent updated to v${LATEST_VER}"
     else
       echo -e "  ${DIM}  keeping v${INSTALLED_VER}${NC}"
@@ -128,10 +128,10 @@ else
   echo -e "  ${BOLD}Installing gitagent...${NC}"
   # Remove corrupted partial installs that cause ENOTDIR
   NPM_GLOBAL_DIR="$(npm root -g 2>/dev/null || echo "")"
-  if [ -n "$NPM_GLOBAL_DIR" ] && [ -d "${NPM_GLOBAL_DIR}/gitagent" ] && [ ! -f "${NPM_GLOBAL_DIR}/gitagent/package.json" ]; then
-    $NPM_CMD rm -rf "${NPM_GLOBAL_DIR}/gitagent" 2>/dev/null
+  if [ -n "$NPM_GLOBAL_DIR" ] && [ -d "${NPM_GLOBAL_DIR}/@open-gitagent/gitagent" ] && [ ! -f "${NPM_GLOBAL_DIR}/@open-gitagent/gitagent/package.json" ]; then
+    $NPM_CMD rm -rf "${NPM_GLOBAL_DIR}/@open-gitagent/gitagent" 2>/dev/null
   fi
-  $NPM_CMD install -g gitagent@latest 2>&1 | tail -2
+  $NPM_CMD install -g @open-gitagent/gitagent@latest 2>&1 | tail -2
   echo -e "  ${GREEN}✓${NC} gitagent installed"
 fi
 echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gitagent",
+  "name": "@open-gitagent/gitagent",
   "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gitagent",
+      "name": "@open-gitagent/gitagent",
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gitagent",
+  "name": "@open-gitagent/gitagent",
   "version": "1.5.0",
   "description": "A universal git-native multimodal always learning AI Agent (TinyHuman)",
   "author": "shreyaskapale",


### PR DESCRIPTION
Switch the npm package name from unscoped `gitagent` (which the CI `NPM_TOKEN` can't create — that was the `404 PUT`) to the existing scoped **`@open-gitagent/gitagent`**, which the token can publish. `1.5.0 > 0.2.0`, so this becomes the new `latest`.

- `package.json` + `package-lock.json`: name → `@open-gitagent/gitagent` (bin stays `gitagent`, version stays 1.5.0)
- `install.sh`: scoped the `npm ls`/`view`/`install` and global-dir refs; the `gitagent` command + display strings unchanged
- `README` + `Documentation`: install command → `npm install -g @open-gitagent/gitagent`

`npm ci` + `npm run build` verified locally; `install.sh` passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)