### PR TITLE
fix(voice): migrate OpenAI Realtime to GA API + make agent .env authoritative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-gitagent/gitagent",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-gitagent/gitagent",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@googleworkspace/cli": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-gitagent/gitagent",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A universal git-native multimodal always learning AI Agent (TinyHuman)",
   "author": "shreyaskapale",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -379,14 +379,18 @@ async function main(): Promise<void> {
 	const envPath = resolve(dir, ".env");
 	if (existsSync(envPath)) {
 		const envContent = readFileSync(envPath, "utf-8");
-		for (const line of envContent.split("\n")) {
+		for (const rawLine of envContent.split("\n")) {
+			const line = rawLine.trim();
+			if (!line || line.startsWith("#")) continue;
 			const eq = line.indexOf("=");
 			if (eq <= 0) continue;
 			const key = line.slice(0, eq).trim();
-			const val = line.slice(eq + 1).trim();
-			if (!process.env[key]) {
-				process.env[key] = val;
+			let val = line.slice(eq + 1).trim();
+			if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+				val = val.slice(1, -1);
 			}
+			// Agent .env wins over inherited env (e.g. a placeholder OPENAI_API_KEY in ~/.zshrc).
+			process.env[key] = val;
 		}
 	}
 

--- a/src/voice/openai-realtime.ts
+++ b/src/voice/openai-realtime.ts
@@ -44,7 +44,6 @@ export class OpenAIRealtimeAdapter implements MultimodalAdapter {
 			await this.connectWs(url, {
 				headers: {
 					Authorization: `Bearer ${this.config.apiKey}`,
-					"OpenAI-Beta": "realtime=v1",
 				},
 			});
 			return;
@@ -83,7 +82,6 @@ export class OpenAIRealtimeAdapter implements MultimodalAdapter {
 		await this.connectWs(url, {
 			headers: {
 				Authorization: `Bearer ${ephemeralKey}`,
-				"OpenAI-Beta": "realtime=v1",
 			},
 		});
 	}
@@ -147,17 +145,26 @@ export class OpenAIRealtimeAdapter implements MultimodalAdapter {
 		const payload = {
 			type: "session.update",
 			session: {
+				type: "realtime",
+				output_modalities: ["audio"],
 				instructions,
-				voice: this.config.voice || "ash",
-				modalities: ["text", "audio"],
-				turn_detection: {
-					type: "server_vad",
-					threshold: 0.6,
-					prefix_padding_ms: 400,
-					silence_duration_ms: 800,
-					create_response: true,
+				audio: {
+					input: {
+						format: { type: "audio/pcm", rate: 24000 },
+						turn_detection: {
+							type: "server_vad",
+							threshold: 0.6,
+							prefix_padding_ms: 400,
+							silence_duration_ms: 800,
+							create_response: true,
+						},
+						transcription: { model: "whisper-1" },
+					},
+					output: {
+						format: { type: "audio/pcm", rate: 24000 },
+						voice: this.config.voice || "ash",
+					},
 				},
-				input_audio_transcription: { model: "whisper-1" },
 				tool_choice: "auto",
 				tools: [
 					{
@@ -285,7 +292,6 @@ export class OpenAIRealtimeAdapter implements MultimodalAdapter {
 				await this.connectWs(url, {
 					headers: {
 						Authorization: `Bearer ${this.config.apiKey}`,
-						"OpenAI-Beta": "realtime=v1",
 					},
 				});
 			} catch (err: any) {
@@ -302,7 +308,6 @@ export class OpenAIRealtimeAdapter implements MultimodalAdapter {
 				const ephemeralKey = session.client_secret?.value;
 				if (!ephemeralKey) throw new Error("No ephemeral key on refresh");
 				await this.connectWs(url, {
-					headers: { Authorization: `Bearer ${ephemeralKey}`, "OpenAI-Beta": "realtime=v1" },
 				});
 			}
 			console.log(dim("[voice] Session refreshed"));
@@ -388,17 +393,21 @@ export class OpenAIRealtimeAdapter implements MultimodalAdapter {
 				this.interrupted = false;
 				break;
 
+			// GA event names are response.output_audio*; keep the beta aliases too.
 			case "response.audio.delta":
+			case "response.output_audio.delta":
 				if (event.delta && !this.interrupted) {
 					this.emit({ type: "audio_delta", audio: event.delta });
 				}
 				break;
 
 			case "response.audio_transcript.delta":
+			case "response.output_audio_transcript.delta":
 				this.emit({ type: "transcript", role: "assistant", text: event.delta || "", partial: true });
 				break;
 
 			case "response.audio_transcript.done":
+			case "response.output_audio_transcript.done":
 				if (event.transcript) {
 					this.emit({ type: "transcript", role: "assistant", text: event.transcript });
 				}

--- a/src/voice/server.ts
+++ b/src/voice/server.ts
@@ -595,9 +595,9 @@ function loadEnvFile(dir: string) {
 			if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
 				val = val.slice(1, -1);
 			}
-			if (!process.env[key]) {
-				process.env[key] = val;
-			}
+			// Agent .env takes precedence over inherited env (e.g. shell placeholders
+			// like a stray OPENAI_API_KEY="your-...-here" in ~/.zshrc).
+			process.env[key] = val;
 		}
 	} catch {
 		// No .env file — that's fine


### PR DESCRIPTION
Voice mode was fully broken on the published package. Two root causes:

### 1. OpenAI killed the Realtime **Beta** API
The adapter sent `OpenAI-Beta: realtime=v1`; the server now rejects it with *"The Realtime Beta API is no longer supported. Please use /v1/realtime for the GA API."* Migrated `src/voice/openai-realtime.ts` to GA:
- Removed the beta header everywhere.
- `session.update` → GA shape: `session.type: "realtime"`, `output_modalities`, nested `audio.input` / `audio.output` (format + `voice` + `turn_detection` + `transcription`). GA also requires `session.type`, which was the `missing_required_parameter` error.
- Handle GA event names `response.output_audio.delta` / `response.output_audio_transcript.*` alongside the old beta names.

### 2. Stray env placeholder shadowed the real key
A `~/.zshrc` line `export OPENAI_API_KEY="your-...-here"` beat the real key in the agent's `.env`, because the loaders only set a var `if (!process.env[key])`. Surfaced to users as the misleading *"no API key set"*. Now the **agent `.env` overrides** inherited env in both `src/index.ts` and `src/voice/server.ts` (index.ts loader also strips quotes / skips comments).

Bumps `1.5.0 → 1.5.1`.

### Verified
Built and run locally against a real key: adapter connects, `Session created` + `Session configured`, no *"Voice mode unavailable"*. `npm ci` + `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)