### PR TITLE
fix: wire file_changed, post_tool_failure, pre_query hooks

### DIFF
--- a/src/plugin-types.ts
+++ b/src/plugin-types.ts
@@ -24,7 +24,10 @@ export interface PluginManifest {
 		hooks?: {
 			on_session_start?: Array<{ script: string; description?: string }>;
 			pre_tool_use?: Array<{ script: string; description?: string }>;
+			post_tool_failure?: Array<{ script: string; description?: string }>;
 			post_response?: Array<{ script: string; description?: string }>;
+			pre_query?: Array<{ script: string; description?: string }>;
+			file_changed?: Array<{ script: string; description?: string }>;
 			on_error?: Array<{ script: string; description?: string }>;
 		};
 		skills?: boolean;

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -376,14 +376,17 @@ export function mergeHooksConfigs(
 		hooks: {
 			on_session_start: [...(base?.hooks.on_session_start || [])],
 			pre_tool_use: [...(base?.hooks.pre_tool_use || [])],
+			post_tool_failure: [...(base?.hooks.post_tool_failure || [])],
 			post_response: [...(base?.hooks.post_response || [])],
+			pre_query: [...(base?.hooks.pre_query || [])],
+			file_changed: [...(base?.hooks.file_changed || [])],
 			on_error: [...(base?.hooks.on_error || [])],
 		},
 	};
 
 	for (const plugin of plugins) {
 		if (!plugin.hooks) continue;
-		for (const event of ["on_session_start", "pre_tool_use", "post_response", "on_error"] as const) {
+		for (const event of ["on_session_start", "pre_tool_use", "post_tool_failure", "post_response", "pre_query", "file_changed", "on_error"] as const) {
 			const pluginHooks = plugin.hooks.hooks[event];
 			if (pluginHooks) {
 				merged.hooks[event] = [...(merged.hooks[event] || []), ...pluginHooks];

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -204,7 +204,7 @@ async function loadPlugin(
 	let hooks: HooksConfig | null = null;
 	if (manifest.provides?.hooks) {
 		const hooksDef: HooksConfig["hooks"] = {};
-		for (const event of ["on_session_start", "pre_tool_use", "post_response", "on_error"] as const) {
+		for (const event of ["on_session_start", "pre_tool_use", "post_tool_failure", "post_response", "pre_query", "file_changed", "on_error"] as const) {
 			const entries = manifest.provides.hooks[event];
 			if (entries && Array.isArray(entries)) {
 				hooksDef[event] = entries.map((e: any) => ({

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -99,6 +99,9 @@ export function query(options: QueryOptions): Query {
 	let accText = "";
 	let accThinking = "";
 
+	// Track tool args by toolCallId so file_changed hook can access them
+	const toolArgsMap = new Map<string, any>();
+
 	function pushMsg(msg: GCMessage) {
 		collectedMessages.push(msg);
 		channel.push(msg);
@@ -427,6 +430,7 @@ export function query(options: QueryOptions): Query {
 				}
 
 				case "tool_execution_start":
+					toolArgsMap.set(event.toolCallId, event.args ?? {});
 					pushMsg({
 						type: "tool_use",
 						toolCallId: event.toolCallId,
@@ -444,6 +448,29 @@ export function query(options: QueryOptions): Query {
 						content: text,
 						isError: event.isError,
 					});
+
+					// Fire post_tool_failure hooks
+					if (event.isError && hooksConfig?.hooks.post_tool_failure) {
+						runHooks(hooksConfig.hooks.post_tool_failure, loaded.agentDir, {
+							event: "post_tool_failure",
+							session_id: _sessionId,
+							tool: event.toolName,
+							error: text,
+						}).catch(() => {});
+					}
+
+					// Fire file_changed hooks for write/edit tools
+					if (!event.isError && hooksConfig?.hooks.file_changed &&
+						(event.toolName === "write" || event.toolName === "edit")) {
+						const toolArgs = toolArgsMap.get(event.toolCallId) ?? {};
+						runHooks(hooksConfig.hooks.file_changed, loaded.agentDir, {
+							event: "file_changed",
+							session_id: _sessionId,
+							tool: event.toolName,
+							file_path: toolArgs.path ?? "",
+						}).catch(() => {});
+					}
+					toolArgsMap.delete(event.toolCallId);
 					break;
 				}
 
@@ -463,6 +490,23 @@ export function query(options: QueryOptions): Query {
 		// gen_ai.chat and gitagent.tool.execute spans become children of
 		// gitagent.agent.session.
 		if (typeof options.prompt === "string") {
+			// Fire pre_query hook before sending to LLM
+			if (hooksConfig?.hooks.pre_query) {
+				const result = await runHooks(hooksConfig.hooks.pre_query, loaded.agentDir, {
+					event: "pre_query",
+					session_id: _sessionId,
+					prompt: options.prompt,
+				});
+				if (result.action === "block") {
+					pushMsg({
+						type: "system",
+						subtype: "hook_blocked",
+						content: `Query blocked by hook: ${result.reason || "no reason given"}`,
+					});
+					channel.finish();
+					return;
+				}
+			}
 			await otelContext.with(_session.ctx, () =>
 				agent.prompt(options.prompt as string),
 			);
@@ -470,6 +514,23 @@ export function query(options: QueryOptions): Query {
 			// Multi-turn: iterate the async iterable
 			for await (const userMsg of options.prompt) {
 				pushMsg({ type: "user", content: userMsg.content });
+				// Fire pre_query hook for each turn
+				if (hooksConfig?.hooks.pre_query) {
+					const result = await runHooks(hooksConfig.hooks.pre_query, loaded.agentDir, {
+						event: "pre_query",
+						session_id: _sessionId,
+						prompt: userMsg.content,
+					});
+					if (result.action === "block") {
+						pushMsg({
+							type: "system",
+							subtype: "hook_blocked",
+							content: `Query blocked by hook: ${result.reason || "no reason given"}`,
+						});
+						channel.finish();
+						return;
+					}
+				}
 				await otelContext.with(_session.ctx, () =>
 					agent.prompt(userMsg.content),
 				);


### PR DESCRIPTION
- mergeHooksConfigs() in plugins.ts was silently dropping 3 hooks
- Added runHooks() triggers in sdk.ts for tool_execution_end and pre_query
- Added toolArgsMap to pass file_path to file_changed hook

Fixes #49