### PR TITLE
feat(env): global ~/.gitagent/.env fallback + auto-reload UI after key save

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,17 @@ PROJECT_DIR="${HOME}/assistant"
 if [ -d "$PROJECT_DIR" ] && [ -f "$PROJECT_DIR/agent.yaml" ]; then
   echo -e "  ${GREEN}✓${NC} Found existing assistant at ${DIM}${PROJECT_DIR}${NC}"
 
+  # Load global ~/.gitagent/.env first as a fallback, then project .env (project wins).
+  # Mirrors the server's loader precedence so keys behave the same way here as at runtime.
+  GLOBAL_ENV="${HOME}/.gitagent/.env"
+  if [ -f "$GLOBAL_ENV" ]; then
+    sed -i.bak 's/\r$//' "$GLOBAL_ENV" && rm -f "$GLOBAL_ENV.bak"
+    set -a
+    source "$GLOBAL_ENV"
+    set +a
+    echo -e "  ${GREEN}✓${NC} Loaded keys from ${DIM}${GLOBAL_ENV}${NC}"
+  fi
+
   # Re-export .env keys into current shell (strip Windows \r line endings)
   if [ -f "$PROJECT_DIR/.env" ]; then
     sed -i.bak 's/\r$//' "$PROJECT_DIR/.env" && rm -f "$PROJECT_DIR/.env.bak"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-gitagent/gitagent",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-gitagent/gitagent",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@googleworkspace/cli": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-gitagent/gitagent",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A universal git-native multimodal always learning AI Agent (TinyHuman)",
   "author": "shreyaskapale",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { formatComplianceWarnings } from "./compliance.js";
 import { readFile, mkdir, writeFile, stat, access } from "fs/promises";
 import { existsSync, readFileSync } from "fs";
 import { join, resolve } from "path";
+import { homedir } from "os";
 import { execSync } from "child_process";
 import { initLocalSession } from "./session.js";
 import type { LocalSession } from "./session.js";
@@ -375,9 +376,10 @@ async function main(): Promise<void> {
 		dir = resolve(dir);
 	}
 
-	// Load .env from agent directory so API keys are available before voice init
-	const envPath = resolve(dir, ".env");
-	if (existsSync(envPath)) {
+	// Env precedence (lowest → highest): inherited env → ~/.gitagent/.env (global fallback) → agent-dir .env (winner).
+	// loadEnvPath is called in that order so the LAST source wins; agent .env still beats a shell placeholder.
+	const loadEnvPath = (envPath: string): void => {
+		if (!existsSync(envPath)) return;
 		const envContent = readFileSync(envPath, "utf-8");
 		for (const rawLine of envContent.split("\n")) {
 			const line = rawLine.trim();
@@ -389,10 +391,11 @@ async function main(): Promise<void> {
 			if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
 				val = val.slice(1, -1);
 			}
-			// Agent .env wins over inherited env (e.g. a placeholder OPENAI_API_KEY in ~/.zshrc).
 			process.env[key] = val;
 		}
-	}
+	};
+	loadEnvPath(join(homedir(), ".gitagent", ".env"));
+	loadEnvPath(resolve(dir, ".env"));
 
 	// Auto-init telemetry after .env is loaded so OTEL_* vars set in .env are picked up.
 	if ((process.env.OTEL_EXPORTER_OTLP_ENDPOINT || process.env.OTEL_TRACES_EXPORTER === "console") && process.env.GITAGENT_OTEL_ENABLED !== "false") {

--- a/src/voice/server.ts
+++ b/src/voice/server.ts
@@ -7,6 +7,7 @@ import { execSync } from "child_process";
 import { join, dirname, resolve, relative } from "path";
 import { writeFile, readFile, mkdir, stat } from "fs/promises";
 import { fileURLToPath } from "url";
+import { homedir } from "os";
 import { OpenAIRealtimeAdapter } from "./openai-realtime.js";
 import { GeminiLiveAdapter } from "./gemini-live.js";
 import { ComposioAdapter } from "../composio/index.js";
@@ -633,7 +634,9 @@ function loadUIHtml(): string {
 }
 
 export async function startVoiceServer(opts: VoiceServerOptions): Promise<() => Promise<void>> {
-	// Load .env from agent directory (won't overwrite existing env vars)
+	// Env precedence (lowest → highest): inherited env → ~/.gitagent/.env (global fallback) → agent-dir .env (winner).
+	// Each loader call overrides whatever's already in process.env, so the LAST load wins.
+	loadEnvFile(join(homedir(), ".gitagent"));
 	loadEnvFile(resolve(opts.agentDir));
 
 	const port = opts.port || 3333;

--- a/src/voice/ui.html
+++ b/src/voice/ui.html
@@ -3038,13 +3038,22 @@ function saveSettings(){
     .then(function(res){
       document.getElementById('settingsSaving').style.display='none';
       if(res.ok){
-        showSettingsStatus('Settings saved. Changes take effect on next query.','success');
-        // Clear password fields and refresh placeholders
+        // Clear password fields immediately (don't leave secrets in the form)
         document.getElementById('settingsOpenaiKey').value='';
         document.getElementById('settingsAnthropicKey').value='';
         document.getElementById('settingsGeminiKey').value='';
         document.getElementById('settingsComposioKey').value='';
-        settingsLoaded=false;loadSettings();settingsLoaded=true;
+        // Voice adapter is created per-WebSocket connection from process.env at connect time.
+        // If keys changed, reload so the next connection picks up the new keys and voice works
+        // without a manual restart.
+        var hasKeyChange=!!(payload.keys && Object.keys(payload.keys).length);
+        if(hasKeyChange){
+          showSettingsStatus('Settings saved — reloading to apply new keys…','success');
+          setTimeout(function(){window.location.reload();},900);
+        }else{
+          showSettingsStatus('Settings saved.','success');
+          settingsLoaded=false;loadSettings();settingsLoaded=true;
+        }
       }else{
         showSettingsStatus(res.data.error||'Failed to save','error');
       }


### PR DESCRIPTION
Three changes so the voice UI always finds env and runs no matter what.

### 1. Global `~/.gitagent/.env` fallback (`src/voice/server.ts`, `src/index.ts`)
New precedence: **inherited env → `~/.gitagent/.env` → agent-dir `.env`**. Each load overrides, so the agent `.env` still wins (per #46), but users can drop keys **once** in `~/.gitagent/.env` and every agent picks them up. Shell placeholders no longer matter.

### 2. Settings save auto-reloads the UI when keys change (`src/voice/ui.html`)
The voice adapter is created per-WebSocket from `process.env` at connect time, so a key change wasn't visible to in-flight connections. `saveSettings()` now reloads after a key write — the next WS connection uses the new key without a manual server restart.

### 3. `install.sh` sources `~/.gitagent/.env` before `$PROJECT_DIR/.env`
Bash script's env precedence now matches the server's. The existing "no key found" prompt still runs if neither file has the key.

Bumps `1.5.1 → 1.5.2`. Verified via grep that the dist has the loader, the reload, and the install.sh block. `bash -n install.sh` clean. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)