### PR TITLE
docs: Remove deprecated npm package mentioned in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,6 @@ gitagent --repo https://github.com/org/repo "Add unit tests"
 
 ### SDK
 
-```bash
-npm install gitagent
-```
-
 ```typescript
 import { query } from "gitagent";
 


### PR DESCRIPTION
Updated docs to remove the confusing "npm install gitagent" command .