### PR TITLE
Add opt-in Parallel Search MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,10 @@ for await (const msg of query({
 
 SDK `mcpServers` are merged with any `agent.yaml` `mcp_servers` (the SDK value wins on a key collision).
 
+### Parallel Search opt-in
+
+Set `parallelSearch: true` in `query()` to connect to the credential-free Streamable HTTP endpoint `https://search.parallel.ai/mcp`; it is disabled by default and preserves an `parallel-search` server (including headers). When its tools are used, user-provided search objectives, search queries, and requested URLs are sent to Parallel. See [Search MCP docs](https://docs.parallel.ai/integrations/mcp/search-mcp).
+
 ### Behavior & guarantees
 
 - **Fail-soft:** a server that can't start (or times out) is logged and skipped — other servers and built-in tools keep working.

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -9,6 +9,13 @@ const _require = createRequire(import.meta.url);
 const { version: PACKAGE_VERSION } = _require("../../package.json") as { version: string };
 
 const DEFAULT_TIMEOUT_MS = 30000;
+const PARALLEL_SEARCH_URL = "https://search.parallel.ai/mcp";
+
+export interface McpSetupOptions {
+	parallelSearch?: boolean;
+	/** Test seam for exercising discovery without network access. */
+	connect?: (name: string, config: McpServerConfig) => Promise<McpConnection | null>;
+}
 
 /** A live connection to one MCP server. */
 interface McpConnection {
@@ -214,14 +221,20 @@ async function connectServer(name: string, rawCfg: McpServerConfig): Promise<Mcp
 export async function setupMcp(
 	servers: Record<string, McpServerConfig> | undefined,
 	existingToolNames: Set<string>,
+	options: McpSetupOptions = {},
 ): Promise<McpSetupResult> {
-	const entries = Object.entries(servers ?? {});
+	const resolved = { ...servers };
+	if (options.parallelSearch && !("parallel-search" in resolved)) {
+		resolved["parallel-search"] = { type: "http", url: PARALLEL_SEARCH_URL };
+	}
+	const entries = Object.entries(resolved);
 	if (entries.length === 0) {
 		return { tools: [], cleanup: async () => {} };
 	}
 
+	const connect = options.connect ?? connectServer;
 	const settled = await Promise.allSettled(
-		entries.map(([name, cfg]) => connectServer(name, cfg)),
+		entries.map(([name, cfg]) => connect(name, cfg)),
 	);
 	const connections = settled
 		.map((s) => (s.status === "fulfilled" ? s.value : null))

--- a/src/sdk-types.ts
+++ b/src/sdk-types.ts
@@ -148,6 +148,8 @@ export interface QueryOptions {
 	sessionId?: string;
 	/** MCP servers to connect to. Merged with manifest `mcp_servers` (these win on key collision). */
 	mcpServers?: Record<string, McpServerConfig>;
+	/** Opt in to the credential-free Parallel Search MCP server. Existing `parallel-search` config wins. */
+	parallelSearch?: boolean;
 	constraints?: {
 		temperature?: number;
 		maxTokens?: number;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -217,7 +217,7 @@ export function query(options: QueryOptions): Query {
 
 		// MCP tools — merge manifest + SDK server configs (SDK wins on key collision)
 		const mcpServers = { ...loaded.manifest.mcp_servers, ...options.mcpServers };
-		mcpSetup = await setupMcp(mcpServers, existingToolNames);
+		mcpSetup = await setupMcp(mcpServers, existingToolNames, { parallelSearch: options.parallelSearch });
 		tools = [...tools, ...mcpSetup.tools];
 
 		// SDK-provided tools

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -165,3 +165,34 @@ describe("setupMcp", () => {
 		await result.cleanup();
 	});
 });
+
+
+describe("Parallel Search opt-in", () => {
+	it("does not connect by default", async () => {
+		let calls = 0;
+		const result = await setupMcp(undefined, new Set(), { connect: async () => { calls++; return null; } });
+		assert.equal(calls, 0);
+		assert.deepEqual(result.tools, []);
+	});
+
+	it("connects and discovers tools only when explicitly enabled", async () => {
+		let received: any;
+		const client = { listTools: async () => ({ tools: [{ name: "web_search", inputSchema: {} }] }), callTool: async () => ({ content: [] }) };
+		const result = await setupMcp(undefined, new Set(), { parallelSearch: true, connect: async (name, config) => {
+			received = { name, config };
+			return { name, client: client as any, close: async () => {} };
+		} });
+
+		assert.deepEqual(received, { name: "parallel-search", config: { type: "http", url: "https://search.parallel.ai/mcp" } });
+		assert.deepEqual(result.tools.map((tool) => tool.name), ["parallel-search__web_search"]);
+		await result.cleanup();
+	});
+
+	it("preserves an existing server with the reserved name", async () => {
+		let received: any;
+		await setupMcp({ "parallel-search": { type: "http", url: "https://user.example/mcp", headers: { "X-Test": "kept" } } }, new Set(), { parallelSearch: true, connect: async (name, config) => { received = { name, config }; return null; } });
+
+		assert.equal(received.config.url, "https://user.example/mcp");
+		assert.deepEqual(received.config.headers, { "X-Test": "kept" });
+	});
+});


### PR DESCRIPTION
## Why

Gitagent SDK users can already configure arbitrary MCP servers. This adds a concise, explicitly enabled path to credential-free web search and URL fetching through that existing runtime.

## Changes

- Add a `parallelSearch: true` SDK option that configures the canonical Streamable HTTP endpoint, `https://search.parallel.ai/mcp`.
- Keep the integration disabled by default and preserve an existing `parallel-search` server, including its URL and headers.
- Document that using the tools sends user-provided search objectives, search queries, and requested URLs to Parallel, with the canonical documentation at https://docs.parallel.ai/integrations/mcp/search-mcp.
- Add mock-client runtime coverage for default no-connection behavior, explicit connection and tool discovery, and name-collision preservation.

## Validation

- `npm run build`: passed.
- `node --test test/mcp.test.ts --experimental-strip-types`: passed (15 tests).
- `node --test test/sdk.test.ts --experimental-strip-types`: passed (19 tests).
- `npm test`: passed (79 tests).
- `git diff --check`: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.